### PR TITLE
Добавлено автоматическое создание сенсоров при подключении к серверу

### DIFF
--- a/Client/src/main/java/readers/CpuInfoCollector.java
+++ b/Client/src/main/java/readers/CpuInfoCollector.java
@@ -1,5 +1,18 @@
 package readers;
 
-public class CpuInfoCollector {
+import entities.devices.Hardware;
 
+import java.util.Collections;
+import java.util.List;
+
+public class CpuInfoCollector implements SensorInfoCollector {
+    @Override
+    public List<? super Hardware> collectInfo() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void updateSensorInfo() {
+
+    }
 }

--- a/Client/src/main/java/readers/RamInfoCollector.java
+++ b/Client/src/main/java/readers/RamInfoCollector.java
@@ -1,5 +1,19 @@
 package readers;
 
-public class RamInfoCollector {
+import entities.devices.Hardware;
+import entities.devices.Ram;
 
+import java.util.Collections;
+import java.util.List;
+
+public class RamInfoCollector implements SensorInfoCollector {
+    @Override
+    public List<? super Hardware> collectInfo() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void updateSensorInfo() {
+
+    }
 }

--- a/Client/src/main/java/services/Client.java
+++ b/Client/src/main/java/services/Client.java
@@ -145,7 +145,9 @@ public class Client {
                         out.write(("\\clientName " + clientParams.get("Client name")).getBytes());
                         break;
                     case "startSensors":
-                        executor.scheduleAtFixedRate(new DeviceListener(out), 0, 5, TimeUnit.SECONDS);
+                        if (query.length >= 2) {
+                            executor.scheduleAtFixedRate(new DeviceListener(out, Arrays.copyOfRange(query, 1, query.length)), 0, 5, TimeUnit.SECONDS);
+                        }
                         break;
                     case "getMac":
                         out.write(("\\macAddress " + getMacAddress()).getBytes());
@@ -236,7 +238,7 @@ public class Client {
             }
             in.close();
             return macAddress;
-        }catch (IOException e){
+        } catch (IOException e) {
             e.printStackTrace();
         }
         return null;

--- a/DirServer/src/main/java/entities/TrackedEquipment.java
+++ b/DirServer/src/main/java/entities/TrackedEquipment.java
@@ -4,6 +4,8 @@ import entities.devices.ClientHardwareInfo;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
@@ -45,6 +47,7 @@ public class TrackedEquipment {
     @Column(name = "updated_at")
     @UpdateTimestamp
     private LocalDateTime updatedAt;
+    @Fetch(FetchMode.JOIN)
     @OneToMany(mappedBy = "trackedEquipment", cascade = CascadeType.ALL)
     private List<TrackedEquipmentSensors> trackedEquipmentSensorsList;
     @Transient

--- a/DirServer/src/main/java/services/ChanelListener.java
+++ b/DirServer/src/main/java/services/ChanelListener.java
@@ -2,7 +2,9 @@ package services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import entities.Connection;
+import entities.Sensors;
 import entities.TrackedEquipment;
+import entities.TrackedEquipmentSensors;
 import entities.devices.ClientHardwareInfo;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -13,7 +15,11 @@ import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static enums.Status.ONLINE;
 
@@ -87,7 +93,14 @@ public class ChanelListener {
                 LOGGER.info(String.format("MAC клиента: [%s]", header[1]));
                 client.getDevice().setEquipmentMacAddress(header[1]);
                 dbService.updateTrackedEquipment(client.getDevice());
-                messageSender.sendMessageWithoutHeader("startSensors");
+                StringBuilder sensors = new StringBuilder();
+                client.getDevice()
+                        .getTrackedEquipmentSensorsList()
+                        .forEach(trackedEquipmentSensors -> sensors.append(" ")
+                                .append(trackedEquipmentSensors
+                                        .getSensors()
+                                        .getSensorTitle()));
+                messageSender.sendMessageWithoutHeader("startSensors" + sensors);
                 break;
             case "/shutdown":
                 server.shutdown();

--- a/DirServer/src/main/java/services/ClientListenersDataBus.java
+++ b/DirServer/src/main/java/services/ClientListenersDataBus.java
@@ -149,5 +149,4 @@ public class ClientListenersDataBus {
         Connection connection = connections.get(index);
         return connection.getDevice().getDeviceInfo();
     }
-
 }

--- a/DirServer/src/main/java/services/DataBaseService.java
+++ b/DirServer/src/main/java/services/DataBaseService.java
@@ -7,7 +7,9 @@ import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Configuration;
 
 
+import javax.persistence.EntityGraph;
 import javax.persistence.NoResultException;
+import javax.persistence.TypedQuery;
 import javax.transaction.Transactional;
 
 @Transactional
@@ -43,7 +45,7 @@ public class DataBaseService {
         session.getTransaction().commit();
         return -1;
     }
-
+    @Transactional
     public TrackedEquipment getTrackedEquipmentByUUID(String uuid) {
         session = factory.getCurrentSession();
         session.beginTransaction();


### PR DESCRIPTION
При подключении клиента к серверу, сервер проверяет (в соответствии с БД) подключенные к клиенту сенсоры и отправляет клиенту команду какие сенсоры необходимо запустить. Клиент принимает команду и создает задание отправлять на сервер информацию от запущенных сенсоров.
Полностью реализован функционал считывания информации о HDD (кроме температуры HDD)